### PR TITLE
Remove duplicates of Arrays of Objects

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,7 +75,8 @@
     "serve": "node server.js",
     "start": "npm run dev",
     "test": "node --experimental-vm-modules node_modules/jest/bin/jest.js",
-    "version": "run-s prepare lint escheck test"
+    "version": "run-s prepare lint escheck test",
+    "postinstall": "npm run build"
   },
   "devDependencies": {
     "browser-sync": "^3.0.2",

--- a/src/index.js
+++ b/src/index.js
@@ -497,11 +497,19 @@ export function mergician(optionsOrObject, ...objects) {
         const propDescriptor = Object.getOwnPropertyDescriptor(obj, key);
         const { configurable, enumerable, writable } = propDescriptor;
 
+        let value = [...new Set(obj[key])];
+
+        // Handle arrays of objects
+        if (Array.isArray(obj[key]) && typeof obj[key][0] === 'object') {
+          value = [...new Set(obj[key].map(item => JSON.stringify(item)))];
+          value = value.map(item => JSON.parse(item));
+        } 
+        
         // Set static value to handle arrays received from srcObj getter
         Object.defineProperty(obj, key, {
           configurable,
           enumerable,
-          value: [...new Set(obj[key])],
+          value: value,
           writable: writable !== undefined ? writable : true
         });
       }


### PR DESCRIPTION
This PR introduces a code change to handle cases where a property of the obj object contains an array of objects. The enhancement ensures that duplicate objects within these arrays are filtered out, maintaining only unique entries.

The original implementation effectively removed duplicates in arrays of primitive values but didn't address arrays containing objects. This oversight could lead to scenarios where duplicate objects remain in properties that should only contain unique entries. The new logic ensures that such duplicates are removed, preserving the integrity of the obj properties.

### Example

**Input**

```json
[{
  "name": "Jusi",
  "numbers": [ 1, 1, 2, 3 ],
  "devices": [
    { "software": "iOS", "name": "iPhone 12'"},
    { "software": "Android", "name": "Pixel 5"}
  ]
},

{
  "name": "Monteiro",
  "numbers": [ 2, 3, 4 ],
  "devices": [
    { "software": "iOS", "name": "iPhone 12" },
    { "software": "Windows", "name": "Surface Pro" }
  ]
}]
```
**Output**

```json
{
  "name": "Monteiro",
  "numbers": [ 1, 2, 3, 4 ],
  "devices": [
    { "software": "iOS", "name": "iPhone 12" },
    { "software": "Android", "name": "Pixel 5" },
    { "software": "Windows", "name": "Surface Pro" }
  ]
}
```

### Note

This package is awesome, very well build, thank you @jhildenbiddle 